### PR TITLE
feat(core): initial project setup with working Pokemon model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,41 +1,82 @@
-# Prerequisites
-*.d
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
 
-# Compiled Object files
-*.slo
-*.lo
+*~
+*.autosave
+*.a
+*.core
+*.moc
 *.o
 *.obj
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Linker files
-*.ilk
-
-# Debugger Files
-*.pdb
-
-# Compiled Dynamic libraries
+*.orig
+*.rej
 *.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-*.smod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
 *.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
 
-# debug information files
-*.dwo
+# qtcreator generated files
+*.pro.user*
+*.qbs.user*
+CMakeLists.txt.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+
+# Directories with generated files
+.moc/
+.obj/
+.pch/
+.rcc/
+.uic/
+/build*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(pokeapi-wrapper-cpp-qt LANGUAGES CXX)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Gui Network)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Network)
+
+add_executable(pokeapi-wrapper-cpp-qt
+  main.cpp
+  model/pokemon.h model/pokemon.cpp
+)
+target_link_libraries(pokeapi-wrapper-cpp-qt
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Network)
+
+include(GNUInstallDirs)
+install(TARGETS pokeapi-wrapper-cpp-qt
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,29 @@
+#include <QCoreApplication>
+#include <QTimer>
+#include <QDebug>
+
+#include "model/pokemon.h"
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication a(argc, argv);
+
+    // Set up code that uses the Qt event loop here.
+    // Call a.quit() or a.exit() to quit the application.
+    // A not very useful example would be including
+    // #include <QTimer>
+    // near the top of the file and calling
+    // QTimer::singleShot(5000, &a, &QCoreApplication::quit);
+    // which quits the application after 5 seconds.
+
+    // If you do not need a running Qt event loop, remove the call
+    // to a.exec() or use the Non-Qt Plain C++ Application template.
+
+    QTimer::singleShot(5000, &a, &QCoreApplication::quit);
+
+    Pokemon pikachu("Pikachu");
+
+    qDebug() << pikachu.name();
+
+    return a.exec();
+}

--- a/model/pokemon.cpp
+++ b/model/pokemon.cpp
@@ -1,0 +1,180 @@
+#include "pokemon.h"
+
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QEventLoop>
+#include <QUrl>
+#include <QDebug>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+
+#include <stdexcept>
+
+namespace {
+const int MIN_ID_POKEMON_VALUE = 1;
+const int MAX_ID_POKEMON_VALUE = 1025;
+
+// JSON keys
+constexpr const char* KEY_NAME = "name";
+constexpr const char* KEY_ID = "id";
+constexpr const char* KEY_HEIGHT = "height";
+constexpr const char* KEY_WEIGHT = "weight";
+constexpr const char* KEY_BASE_EXPERIENCE = "base_experience";
+
+constexpr const char* KEY_TYPES = "types";
+constexpr const char* KEY_TYPE = "type";
+
+constexpr const char* KEY_ABILITIES = "abilities";
+constexpr const char* KEY_ABILITY = "ability";
+
+constexpr const char* KEY_SPRITES = "sprites";
+constexpr const char* KEY_OTHER = "other";
+constexpr const char* KEY_OFFICIAL_ARTWORK = "official-artwork";
+constexpr const char* KEY_FRONT_DEFAULT = "front_default";
+}
+
+Pokemon::Pokemon(int id)
+{
+    if (id < MIN_ID_POKEMON_VALUE || id > MAX_ID_POKEMON_VALUE) {
+        throw std::runtime_error(
+            QString("The id parameter should be between %1 and %2.")
+                .arg(MIN_ID_POKEMON_VALUE)
+                .arg(MAX_ID_POKEMON_VALUE)
+                .toStdString());
+    }
+    QJsonObject jsonObj = fetchPokemonJson(QString::number(id));
+    parseFromJson(jsonObj);
+}
+
+Pokemon::Pokemon(const QString &name)
+{
+    QJsonObject jsonObj = fetchPokemonJson(name);
+    parseFromJson(jsonObj);
+}
+
+QJsonObject Pokemon::fetchPokemonJson(const QString& identifier)
+{
+    QNetworkAccessManager manager;
+    const QUrl url = QString("https://pokeapi.co/api/v2/pokemon/%1").arg(identifier);
+    const QNetworkRequest request(url);
+    const std::shared_ptr<QNetworkReply> reply(manager.get(request));
+
+    // Waiting reply finish in a 'synchronous' way
+    QEventLoop loop;
+    QObject::connect(reply.get(), &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    if (reply->error() != QNetworkReply::NoError) {
+        throw std::runtime_error(QString("Invalid parameter: %1").arg(identifier).toStdString());
+    }
+
+    const QByteArray rawContent = reply->readAll();
+    const QJsonDocument jsonDoc = QJsonDocument::fromJson(rawContent);
+
+    if (!jsonDoc.isObject()) {
+        throw std::runtime_error("Response JSON is not an object.");
+    }
+
+    return jsonDoc.object();
+}
+
+void Pokemon::parseFromJson(const QJsonObject& jsonObj)
+{
+    m_name = jsonObj[KEY_NAME].toString();
+    m_id = jsonObj[KEY_ID].toInt();
+
+    m_height = jsonObj[KEY_HEIGHT].toInt();
+    m_weight = jsonObj[KEY_WEIGHT].toInt();
+    m_baseExperience = jsonObj[KEY_BASE_EXPERIENCE].toInt();
+
+    // Parse types
+    m_types.clear();
+    const QJsonArray typesArray = jsonObj[KEY_TYPES].toArray();
+    for (const auto& typeValue : typesArray) {
+        QJsonObject typeObj = typeValue.toObject();
+        QJsonObject typeInfo = typeObj[KEY_TYPE].toObject();
+        m_types.append(typeInfo[KEY_NAME].toString());
+    }
+
+    // Parse abilities
+    m_abilities.clear();
+    const QJsonArray abilitiesArray = jsonObj[KEY_ABILITIES].toArray();
+    for (const auto& abilityValue : std::as_const(abilitiesArray)) {
+        QJsonObject abilityObj = abilityValue.toObject();
+        QJsonObject abilityInfo = abilityObj[KEY_ABILITY].toObject();
+        m_abilities.append(abilityInfo[KEY_NAME].toString());
+    }
+
+    // Parse official-artwork sprite
+    const QJsonObject spritesObj = jsonObj[KEY_SPRITES].toObject();
+    const QJsonObject otherObj = spritesObj[KEY_OTHER].toObject();
+    const QJsonObject officialArtworkObj = otherObj[KEY_OFFICIAL_ARTWORK].toObject();
+
+    if (!officialArtworkObj.isEmpty()) {
+        QNetworkAccessManager imgManager;
+        const QUrl imgUrl = officialArtworkObj[KEY_FRONT_DEFAULT].toString();
+
+        const QNetworkRequest imgRequest(imgUrl);
+        const std::shared_ptr<QNetworkReply> imgReply(imgManager.get(imgRequest));
+
+        QEventLoop loop;
+        QObject::connect(imgReply.get(), &QNetworkReply::finished, &loop, &QEventLoop::quit);
+        loop.exec();
+
+        if (imgReply->error() == QNetworkReply::NoError) {
+            const QByteArray imgData = imgReply->readAll();
+            m_sprite.loadFromData(imgData);
+        } else {
+            qWarning() << "Failed to load official artwork sprite:" << imgReply->errorString();
+        }
+
+        imgReply->deleteLater();
+    } else {
+        qWarning() << "No official artwork found.";
+        m_sprite = QImage(); // vazio
+    }
+}
+
+
+// Getters implementation
+int Pokemon::id() const
+{
+    return m_id;
+}
+
+QString Pokemon::name() const
+{
+    return m_name;
+}
+
+QVector<QString> Pokemon::types() const
+{
+    return m_types;
+}
+
+QVector<QString> Pokemon::abilities() const
+{
+    return m_abilities;
+}
+
+std::optional<int> Pokemon::height() const
+{
+    return m_height;
+}
+
+std::optional<int> Pokemon::weight() const
+{
+    return m_weight;
+}
+
+std::optional<int> Pokemon::baseExperience() const
+{
+    return m_baseExperience;
+}
+
+const QImage& Pokemon::sprite() const
+{
+    return m_sprite;
+}

--- a/model/pokemon.h
+++ b/model/pokemon.h
@@ -1,0 +1,49 @@
+#ifndef POKEMON_H
+#define POKEMON_H
+
+#include <QString>
+#include <QImage>
+#include <QVector>
+#include <optional>
+#include <QJsonObject>
+
+class Pokemon
+{
+public:
+    Pokemon() = delete;
+
+    explicit Pokemon(int id);
+
+    explicit Pokemon(const QString& name);
+
+    int id() const;
+
+    QString name() const;
+
+    QVector<QString> types() const;
+
+    QVector<QString> abilities() const;
+
+    std::optional<int> height() const;
+
+    std::optional<int> weight() const;
+
+    std::optional<int> baseExperience() const;
+
+    const QImage& sprite() const;
+
+private:
+    int m_id;
+    QString m_name;
+    QVector<QString> m_types;
+    QVector<QString> m_abilities;
+    std::optional<int> m_height;
+    std::optional<int> m_weight;
+    std::optional<int> m_baseExperience;
+    QImage m_sprite;
+
+    QJsonObject fetchPokemonJson(const QString& identifier);
+    void parseFromJson(const QJsonObject& jsonObj);
+};
+
+#endif // POKEMON_H


### PR DESCRIPTION
- Add class Pokemon with support for fetching and parsing data from PokeAPI
- Add sprite loading from official artwork
- Setup CMakeLists with required Qt modules (Core, Gui, Network)
- Demonstrate usage in main.cpp with basic debug output

Limitations:
- This is a minimal version of the Pokemon model
- Only supports a subset of fields: name, id, height, weight, base experience, types, abilities, and official artwork
- Error handling is basic and blocking requests are used (will be improved later)