### PR TITLE
feat(model): add unit tests and JSON keys extraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,13 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Gui Network)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Network)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Gui Network Test)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Network Test)
 
 add_executable(pokeapi-wrapper-cpp-qt
   main.cpp
   model/pokemon.h model/pokemon.cpp
+  model/json_keys.h
 )
 target_link_libraries(pokeapi-wrapper-cpp-qt
     Qt${QT_VERSION_MAJOR}::Core
@@ -26,3 +27,5 @@ install(TARGETS pokeapi-wrapper-cpp-qt
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
+add_subdirectory(tests)

--- a/model/json_keys.h
+++ b/model/json_keys.h
@@ -1,0 +1,29 @@
+#ifndef JSON_KEYS_H
+#define JSON_KEYS_H
+
+namespace JsonKeys {
+
+namespace Common {
+inline constexpr const char *NAME = "name";
+inline constexpr const char *URL = "url";
+} // namespace Common
+
+namespace Pokemon {
+inline constexpr const char *ID = "id";
+inline constexpr const char *NAME = JsonKeys::Common::NAME;
+inline constexpr const char *HEIGHT = "height";
+inline constexpr const char *WEIGHT = "weight";
+inline constexpr const char *BASE_EXPERIENCE = "base_experience";
+inline constexpr const char *TYPES = "types";
+inline constexpr const char *TYPE = "type";
+inline constexpr const char *ABILITIES = "abilities";
+inline constexpr const char *ABILITY = "ability";
+inline constexpr const char *SPRITES = "sprites";
+inline constexpr const char *OTHER = "other";
+inline constexpr const char *OFFICIAL_ARTWORK = "official-artwork";
+inline constexpr const char *FRONT_DEFAULT = "front_default";
+} // namespace Pokemon
+
+} // namespace JsonKeys
+
+#endif // JSON_KEYS_H

--- a/model/pokemon.cpp
+++ b/model/pokemon.cpp
@@ -1,4 +1,5 @@
 #include "pokemon.h"
+#include "json_keys.h"
 
 #include <QDebug>
 #include <QEventLoop>
@@ -12,146 +13,144 @@
 
 #include <stdexcept>
 
-namespace {
-const int MIN_ID_POKEMON_VALUE = 1;
-const int MAX_ID_POKEMON_VALUE = 1025;
-
-// JSON keys
-constexpr const char *KEY_NAME = "name";
-constexpr const char *KEY_ID = "id";
-constexpr const char *KEY_HEIGHT = "height";
-constexpr const char *KEY_WEIGHT = "weight";
-constexpr const char *KEY_BASE_EXPERIENCE = "base_experience";
-
-constexpr const char *KEY_TYPES = "types";
-constexpr const char *KEY_TYPE = "type";
-
-constexpr const char *KEY_ABILITIES = "abilities";
-constexpr const char *KEY_ABILITY = "ability";
-
-constexpr const char *KEY_SPRITES = "sprites";
-constexpr const char *KEY_OTHER = "other";
-constexpr const char *KEY_OFFICIAL_ARTWORK = "official-artwork";
-constexpr const char *KEY_FRONT_DEFAULT = "front_default";
-} // namespace
-
-Pokemon::Pokemon(int id) {
-  if (id < MIN_ID_POKEMON_VALUE || id > MAX_ID_POKEMON_VALUE) {
-    throw std::runtime_error(
-        QString("The id parameter should be between %1 and %2.")
-            .arg(MIN_ID_POKEMON_VALUE)
-            .arg(MAX_ID_POKEMON_VALUE)
-            .toStdString());
-  }
-  QJsonObject jsonObj = fetchPokemonJson(QString::number(id));
-  parseFromJson(jsonObj);
+Pokemon::Pokemon(int id)
+{
+    if (id < PokemonConstants::MIN_ID || id > PokemonConstants::MAX_ID) {
+        throw std::runtime_error(QString("The id parameter should be between %1 and %2.")
+                                     .arg(PokemonConstants::MIN_ID)
+                                     .arg(PokemonConstants::MAX_ID)
+                                     .toStdString());
+    }
+    QJsonObject jsonObj = fetchPokemonJson(QString::number(id));
+    parseFromJson(jsonObj);
 }
 
-Pokemon::Pokemon(const QString &name) {
-  QJsonObject jsonObj = fetchPokemonJson(name);
-  parseFromJson(jsonObj);
+Pokemon::Pokemon(const QString &name)
+{
+    QJsonObject jsonObj = fetchPokemonJson(name);
+    parseFromJson(jsonObj);
 }
 
-QJsonObject Pokemon::fetchPokemonJson(const QString &identifier) {
-  QNetworkAccessManager manager;
-  const QUrl url =
-      QString("https://pokeapi.co/api/v2/pokemon/%1").arg(identifier);
-  const QNetworkRequest request(url);
-  const std::shared_ptr<QNetworkReply> reply(manager.get(request));
+QJsonObject Pokemon::fetchPokemonJson(const QString &identifier)
+{
+    QNetworkAccessManager manager;
+    const QUrl url = QString("https://pokeapi.co/api/v2/pokemon/%1").arg(identifier);
+    const QNetworkRequest request(url);
+    const std::shared_ptr<QNetworkReply> reply(manager.get(request));
 
-  // Waiting reply finish in a 'synchronous' way
-  QEventLoop loop;
-  QObject::connect(reply.get(), &QNetworkReply::finished, &loop,
-                   &QEventLoop::quit);
-  loop.exec();
-
-  if (reply->error() != QNetworkReply::NoError) {
-    throw std::runtime_error(
-        QString("Invalid parameter: %1").arg(identifier).toStdString());
-  }
-
-  const QByteArray rawContent = reply->readAll();
-  const QJsonDocument jsonDoc = QJsonDocument::fromJson(rawContent);
-
-  if (!jsonDoc.isObject()) {
-    throw std::runtime_error("Response JSON is not an object.");
-  }
-
-  return jsonDoc.object();
-}
-
-void Pokemon::parseFromJson(const QJsonObject &jsonObj) {
-  m_name = jsonObj[KEY_NAME].toString();
-  m_id = jsonObj[KEY_ID].toInt();
-
-  m_height = jsonObj[KEY_HEIGHT].toInt();
-  m_weight = jsonObj[KEY_WEIGHT].toInt();
-  m_baseExperience = jsonObj[KEY_BASE_EXPERIENCE].toInt();
-
-  // Parse types
-  m_types.clear();
-  const QJsonArray typesArray = jsonObj[KEY_TYPES].toArray();
-  for (const auto &typeValue : typesArray) {
-    QJsonObject typeObj = typeValue.toObject();
-    QJsonObject typeInfo = typeObj[KEY_TYPE].toObject();
-    m_types.append(typeInfo[KEY_NAME].toString());
-  }
-
-  // Parse abilities
-  m_abilities.clear();
-  const QJsonArray abilitiesArray = jsonObj[KEY_ABILITIES].toArray();
-  for (const auto &abilityValue : std::as_const(abilitiesArray)) {
-    QJsonObject abilityObj = abilityValue.toObject();
-    QJsonObject abilityInfo = abilityObj[KEY_ABILITY].toObject();
-    m_abilities.append(abilityInfo[KEY_NAME].toString());
-  }
-
-  // Parse official-artwork sprite
-  const QJsonObject spritesObj = jsonObj[KEY_SPRITES].toObject();
-  const QJsonObject otherObj = spritesObj[KEY_OTHER].toObject();
-  const QJsonObject officialArtworkObj =
-      otherObj[KEY_OFFICIAL_ARTWORK].toObject();
-
-  if (!officialArtworkObj.isEmpty()) {
-    QNetworkAccessManager imgManager;
-    const QUrl imgUrl = officialArtworkObj[KEY_FRONT_DEFAULT].toString();
-
-    const QNetworkRequest imgRequest(imgUrl);
-    const std::shared_ptr<QNetworkReply> imgReply(imgManager.get(imgRequest));
-
+    // Waiting reply finish in a 'synchronous' way
     QEventLoop loop;
-    QObject::connect(imgReply.get(), &QNetworkReply::finished, &loop,
-                     &QEventLoop::quit);
+    QObject::connect(reply.get(), &QNetworkReply::finished, &loop, &QEventLoop::quit);
     loop.exec();
 
-    if (imgReply->error() == QNetworkReply::NoError) {
-      const QByteArray imgData = imgReply->readAll();
-      m_sprite.loadFromData(imgData);
-    } else {
-      qWarning() << "Failed to load official artwork sprite:"
-                 << imgReply->errorString();
+    if (reply->error() != QNetworkReply::NoError) {
+        throw std::runtime_error(QString("Invalid parameter: %1").arg(identifier).toStdString());
     }
 
-    imgReply->deleteLater();
-  } else {
-    qWarning() << "No official artwork found.";
-    m_sprite = QImage(); // vazio
-  }
+    const QByteArray rawContent = reply->readAll();
+    const QJsonDocument jsonDoc = QJsonDocument::fromJson(rawContent);
+
+    if (!jsonDoc.isObject()) {
+        throw std::runtime_error("Response JSON is not an object.");
+    }
+
+    return jsonDoc.object();
+}
+
+void Pokemon::parseFromJson(const QJsonObject &jsonObj)
+{
+    m_name = jsonObj[JsonKeys::Pokemon::NAME].toString();
+    m_id = jsonObj[JsonKeys::Pokemon::ID].toInt();
+
+    m_height = jsonObj[JsonKeys::Pokemon::HEIGHT].toInt();
+    m_weight = jsonObj[JsonKeys::Pokemon::WEIGHT].toInt();
+    m_baseExperience = jsonObj[JsonKeys::Pokemon::BASE_EXPERIENCE].toInt();
+
+    // Parse types
+    m_types.clear();
+    const QJsonArray typesArray = jsonObj[JsonKeys::Pokemon::TYPES].toArray();
+    for (const auto &typeValue : typesArray) {
+        QJsonObject typeObj = typeValue.toObject();
+        QJsonObject typeInfo = typeObj[JsonKeys::Pokemon::TYPE].toObject();
+        m_types.append(typeInfo[JsonKeys::Pokemon::NAME].toString());
+    }
+
+    // Parse abilities
+    m_abilities.clear();
+    const QJsonArray abilitiesArray = jsonObj[JsonKeys::Pokemon::ABILITIES].toArray();
+    for (const auto &abilityValue : std::as_const(abilitiesArray)) {
+        QJsonObject abilityObj = abilityValue.toObject();
+        QJsonObject abilityInfo = abilityObj[JsonKeys::Pokemon::ABILITY].toObject();
+        m_abilities.append(abilityInfo[JsonKeys::Pokemon::NAME].toString());
+    }
+
+    // Parse official-artwork sprite
+    const QJsonObject spritesObj = jsonObj[JsonKeys::Pokemon::SPRITES].toObject();
+    const QJsonObject otherObj = spritesObj[JsonKeys::Pokemon::OTHER].toObject();
+    const QJsonObject officialArtworkObj = otherObj[JsonKeys::Pokemon::OFFICIAL_ARTWORK].toObject();
+
+    if (!officialArtworkObj.isEmpty()) {
+        QNetworkAccessManager imgManager;
+        const QUrl imgUrl = officialArtworkObj[JsonKeys::Pokemon::FRONT_DEFAULT].toString();
+
+        const QNetworkRequest imgRequest(imgUrl);
+        const std::shared_ptr<QNetworkReply> imgReply(imgManager.get(imgRequest));
+
+        QEventLoop loop;
+        QObject::connect(imgReply.get(), &QNetworkReply::finished, &loop, &QEventLoop::quit);
+        loop.exec();
+
+        if (imgReply->error() == QNetworkReply::NoError) {
+            const QByteArray imgData = imgReply->readAll();
+            m_sprite.loadFromData(imgData);
+        } else {
+            qWarning() << "Failed to load official artwork sprite:" << imgReply->errorString();
+        }
+
+        imgReply->deleteLater();
+    } else {
+        qWarning() << "No official artwork found.";
+        m_sprite = QImage(); // vazio
+    }
 }
 
 // Getters implementation
-int Pokemon::id() const { return m_id; }
+int Pokemon::id() const
+{
+    return m_id;
+}
 
-QString Pokemon::name() const { return m_name; }
+QString Pokemon::name() const
+{
+    return m_name;
+}
 
-QVector<QString> Pokemon::types() const { return m_types; }
+QVector<QString> Pokemon::types() const
+{
+    return m_types;
+}
 
-QVector<QString> Pokemon::abilities() const { return m_abilities; }
+QVector<QString> Pokemon::abilities() const
+{
+    return m_abilities;
+}
 
-std::optional<int> Pokemon::height() const { return m_height; }
+std::optional<int> Pokemon::height() const
+{
+    return m_height;
+}
 
-std::optional<int> Pokemon::weight() const { return m_weight; }
+std::optional<int> Pokemon::weight() const
+{
+    return m_weight;
+}
 
-std::optional<int> Pokemon::baseExperience() const { return m_baseExperience; }
+std::optional<int> Pokemon::baseExperience() const
+{
+    return m_baseExperience;
+}
 
-const QImage &Pokemon::sprite() const { return m_sprite; }
+const QImage &Pokemon::sprite() const
+{
+    return m_sprite;
+}

--- a/model/pokemon.h
+++ b/model/pokemon.h
@@ -7,42 +7,48 @@
 #include <QVector>
 #include <optional>
 
-class Pokemon {
+namespace PokemonConstants {
+inline constexpr int MIN_ID = 1;
+inline constexpr int MAX_ID = 1025;
+} // namespace PokemonConstants
+
+class Pokemon
+{
 public:
-  Pokemon() = delete;
+    Pokemon() = delete;
 
-  explicit Pokemon(int id);
+    explicit Pokemon(int id);
 
-  explicit Pokemon(const QString &name);
+    explicit Pokemon(const QString &name);
 
-  int id() const;
+    int id() const;
 
-  QString name() const;
+    QString name() const;
 
-  QVector<QString> types() const;
+    QVector<QString> types() const;
 
-  QVector<QString> abilities() const;
+    QVector<QString> abilities() const;
 
-  std::optional<int> height() const;
+    std::optional<int> height() const;
 
-  std::optional<int> weight() const;
+    std::optional<int> weight() const;
 
-  std::optional<int> baseExperience() const;
+    std::optional<int> baseExperience() const;
 
-  const QImage &sprite() const;
+    const QImage &sprite() const;
 
 private:
-  int m_id;
-  QString m_name;
-  QVector<QString> m_types;
-  QVector<QString> m_abilities;
-  std::optional<int> m_height;
-  std::optional<int> m_weight;
-  std::optional<int> m_baseExperience;
-  QImage m_sprite;
+    int m_id;
+    QString m_name;
+    QVector<QString> m_types;
+    QVector<QString> m_abilities;
+    std::optional<int> m_height;
+    std::optional<int> m_weight;
+    std::optional<int> m_baseExperience;
+    QImage m_sprite;
 
-  QJsonObject fetchPokemonJson(const QString &identifier);
-  void parseFromJson(const QJsonObject &jsonObj);
+    QJsonObject fetchPokemonJson(const QString &identifier);
+    void parseFromJson(const QJsonObject &jsonObj);
 };
 
 #endif // POKEMON_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,3 @@
+# tests/CMakeLists.txt
+
+add_subdirectory(model)

--- a/tests/model/CMakeLists.txt
+++ b/tests/model/CMakeLists.txt
@@ -1,0 +1,23 @@
+# tests/model/CMakeLists.txt
+
+enable_testing()
+
+add_executable(test_pokemon
+    test_pokemon.cpp
+    ${CMAKE_SOURCE_DIR}/model/pokemon.cpp
+)
+
+target_include_directories(test_pokemon
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/model
+)
+
+target_link_libraries(test_pokemon
+    PRIVATE
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Network
+    Qt${QT_VERSION_MAJOR}::Test
+)
+
+add_test(NAME PokemonTests COMMAND test_pokemon)

--- a/tests/model/test_pokemon.cpp
+++ b/tests/model/test_pokemon.cpp
@@ -1,0 +1,64 @@
+#include <QtTest/QtTest>
+
+#include "../model/pokemon.h"
+
+class TestPokemon : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testCreateById_valid();
+    void testCreateByName_valid();
+    void testCreateById_invalid();
+    void testCreateByName_invalid();
+};
+
+static void assertIsValidPikachu(const Pokemon &p)
+{
+    QCOMPARE(p.id(), 25);
+    QCOMPARE(p.name(), QString("pikachu"));
+
+    QVERIFY(p.height().has_value());
+    QCOMPARE(p.height().value(), 4);
+
+    QVERIFY(p.weight().has_value());
+    QCOMPARE(p.weight().value(), 60);
+
+    QVERIFY(p.baseExperience().has_value());
+    QCOMPARE(p.baseExperience().value(), 112);
+
+    QVERIFY(!p.types().isEmpty());
+    QVERIFY(p.types().contains("electric"));
+
+    QVERIFY(!p.abilities().isEmpty());
+    QVERIFY(p.abilities().contains("static"));
+    QVERIFY(p.abilities().contains("lightning-rod"));
+
+    QVERIFY(!p.sprite().isNull());
+}
+
+void TestPokemon::testCreateById_valid()
+{
+    Pokemon p(25);
+    assertIsValidPikachu(p);
+}
+
+void TestPokemon::testCreateByName_valid()
+{
+    Pokemon p("pikachu");
+    assertIsValidPikachu(p);
+}
+
+void TestPokemon::testCreateById_invalid()
+{
+    QVERIFY_THROWS_EXCEPTION(std::runtime_error, Pokemon(PokemonConstants::MIN_ID - 1));
+    QVERIFY_THROWS_EXCEPTION(std::runtime_error, Pokemon(PokemonConstants::MAX_ID + 1));
+}
+
+void TestPokemon::testCreateByName_invalid()
+{
+    QVERIFY_THROWS_EXCEPTION(std::runtime_error, Pokemon("invalidname"));
+}
+
+QTEST_MAIN(TestPokemon)
+#include "test_pokemon.moc"


### PR DESCRIPTION
- Add unit tests for Pokemon model using Qt Test framework
- Structure tests under tests/model with dedicated CMakeLists.txt
- Introduce helper function assertIsValidPikachu to centralize validation logic
- Extract JSON key string constants from anonymous namespace in pokemon.cpp to model/json_keys.h
- Replace raw string literals with inline constexpr constants for safer and consistent usage
- Enable reuse of JSON keys constants in implementation, tests, and future modules
- Improve code maintainability by reducing duplication and risk of typos
- Integrate test executable with CMake and enable testing via ctest

Notes:
- Tests cover valid and invalid Pokemon creation by ID and name
- Setup allows easy addition of new model tests and scalable test structure